### PR TITLE
Added dns cleanup container

### DIFF
--- a/pkg/ecso/templates/environment_datadog_agent.go
+++ b/pkg/ecso/templates/environment_datadog_agent.go
@@ -60,42 +60,4 @@ Resources:
         Properties:
             LogGroupName: !Ref AWS::StackName
             RetentionInDays: 30
-
-    # This IAM Role grants the service access to register/unregister with the
-    # Application Load Balancer (ALB). It is based on the default documented here:
-    # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
-    ServiceRole:
-        Type: AWS::IAM::Role
-        Properties:
-            RoleName: !Sub ecs-service-${AWS::StackName}
-            Path: /
-            AssumeRolePolicyDocument: |
-                {
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Principal": { "Service": [ "ecs.amazonaws.com" ]},
-                        "Action": [ "sts:AssumeRole" ]
-                    }]
-                }
-            Policies:
-                - PolicyName: !Sub ecs-service-${AWS::StackName}
-                  PolicyDocument:
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [{
-                                "Effect": "Allow",
-                                "Action": [
-                                    "ec2:AuthorizeSecurityGroupIngress",
-                                    "ec2:Describe*",
-                                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                                    "elasticloadbalancing:Describe*",
-                                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                                    "elasticloadbalancing:DeregisterTargets",
-                                    "elasticloadbalancing:DescribeTargetGroups",
-                                    "elasticloadbalancing:DescribeTargetHealth",
-                                    "elasticloadbalancing:RegisterTargets"
-                                ],
-                                "Resource": "*"
-                        }]
-                    }
 `))

--- a/pkg/ecso/templates/environment_dns_cleaner.go
+++ b/pkg/ecso/templates/environment_dns_cleaner.go
@@ -1,0 +1,75 @@
+package templates
+
+import "text/template"
+
+var environmentDNSCleanerTemplate = template.Must(template.New("environmentDNSCleanerTemplate").Parse(`
+Parameters:
+    EnvironmentName:
+        Description: An environment name that will be prefixed to resource names
+        Type: String
+
+    DNSZone:
+        Description: Select the DNS zone to clean
+        Type: String
+
+Resources:
+    TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+            Family: !Sub ${EnvironmentName}-dns-cleaner
+            TaskRoleArn: !Ref TaskRole
+            ContainerDefinitions:
+                - Name: dns-cleaner
+                  Command:
+                      - go-wrapper
+                      - run
+                      - -region
+                      - !Ref AWS::Region
+                      - -zone
+                      - !Sub "${DNSZone}."
+                      - -records
+                      - !Sub "*.${EnvironmentName}.${DNSZone}."
+                  Essential: true
+                  Image: bernos/ecso-dns-cleaner:latest
+                  Cpu: 10
+                  Memory: 128
+                  LogConfiguration:
+                    LogDriver: awslogs
+                    Options:
+                        awslogs-group: !Ref AWS::StackName
+                        awslogs-region: !Ref AWS::Region
+
+    CloudWatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Ref AWS::StackName
+            RetentionInDays: 30
+
+    TaskRole:
+        Type: AWS::IAM::Role
+        Properties:
+            RoleName: !Sub ${EnvironmentName}-dns-cleaner-role
+            Path: /
+            AssumeRolePolicyDocument: |
+                {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": { "Service": [ "ecs-tasks.amazonaws.com" ]},
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                }
+            Policies:
+                - PolicyName: !Sub ecs-service-${AWS::StackName}
+                  PolicyDocument:
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ec2:Describe*",
+                                    "route53:*"
+                                ],
+                                "Resource": "*"
+                        }]
+                    }
+`))

--- a/pkg/ecso/templates/environment_stack.go
+++ b/pkg/ecso/templates/environment_stack.go
@@ -88,6 +88,14 @@ Resources:
             Parameters:
                 EnvironmentName: !Ref AWS::StackName
 
+    DNSCleanerTaskDefinition:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./dns-cleaner.yaml
+            Parameters:
+                EnvironmentName: !Ref AWS::StackName
+                DNSZone: !Ref DNSZone
+
     ALB:
         Type: AWS::CloudFormation::Stack
         Properties:

--- a/pkg/ecso/templates/templates.go
+++ b/pkg/ecso/templates/templates.go
@@ -21,6 +21,7 @@ func GetEnvironmentTemplates(project *ecso.Project, env *ecso.Environment) map[s
 		p("dd-agent.yaml"):        environmentDataDogTemplate,
 		p("sns.yaml"):             environmentSNSTemplate,
 		p("alarms.yaml"):          environmentAlarmsTemplate,
+		p("dns-cleaner.yaml"):     environmentDNSCleanerTemplate,
 	}
 }
 


### PR DESCRIPTION
Adds an instance of the bernos/ecso-dns-cleaner task to each container instance in the cluster. The dns cleaner will remove any route53 SRV records that point to ec2 instances that are no longer running