### PR TITLE
Service discovery lambda

### DIFF
--- a/pkg/ecso/api/serviceapi.go
+++ b/pkg/ecso/api/serviceapi.go
@@ -518,7 +518,7 @@ func (api *serviceAPI) registerECSTaskDefinition(project *ecso.Project, env *ecs
 func (api *serviceAPI) clearServiceDNSRecords(env *ecso.Environment, service *ecso.Service, w io.Writer) error {
 	var (
 		r53Helper = helpers.NewRoute53Helper(api.route53API)
-		dnsName   = fmt.Sprintf("%s.%s.", service.Name, env.CloudFormationParameters["DNSZone"])
+		dnsName   = fmt.Sprintf("%s.%s.%s.", service.Name, env.GetClusterName(), env.CloudFormationParameters["DNSZone"])
 		info      = ui.NewInfoWriter(w)
 	)
 

--- a/pkg/ecso/resources/environment/cloudformation/ecs-cluster.yaml
+++ b/pkg/ecso/resources/environment/cloudformation/ecs-cluster.yaml
@@ -291,7 +291,6 @@ Resources:
                     install_all:
                         - install_cfn
                         - install_logs
-                        - install_ecssd_agent
                         - install_dd_agent
                         - install_dns_cleaner
 
@@ -460,29 +459,6 @@ Resources:
                                 unsureRunning: true
                                 files:
                                     - /etc/awslogs/awslogs.conf
-
-                install_ecssd_agent:
-                    commands:
-                        start_ecssd_agent:
-                            command: "start ecssd-agent"
-
-                    files:
-                        "/etc/init/ecssd-agent.conf":
-                            mode: "000644"
-                            owner: root
-                            group: root
-                            content: !Sub |
-                                description "Amazon EC2 Container Service Discovery"
-                                author "Javieros Ros"
-                                start on stopped rc RUNLEVEL=[345]
-                                exec /usr/local/bin/ecssd_agent ${DNSZone} >> /var/log/ecssd_agent.log 2>&1
-                                respawn
-
-                        "/usr/local/bin/ecssd_agent":
-                            source: https://github.com/awslabs/service-discovery-ecs-dns/releases/download/1.2/ecssd_agent
-                            mode: "000755"
-                            owner: root
-                            group: root
 
     # This IAM Role is attached to all of the ECS hosts. It is based on the default role
     # published here:

--- a/pkg/ecso/resources/environment/cloudformation/service-discovery.yaml
+++ b/pkg/ecso/resources/environment/cloudformation/service-discovery.yaml
@@ -46,6 +46,7 @@ Resources:
             Environment:
                 Variables:
                     DNS_ZONE: !Ref DNSZone
+                    CLUSTER_NAME: !Ref EnvironmentName
             Code:
                 S3Bucket: !Ref S3BucketName
                 S3Key: !Ref S3Key

--- a/pkg/ecso/resources/environment/cloudformation/service-discovery.yaml
+++ b/pkg/ecso/resources/environment/cloudformation/service-discovery.yaml
@@ -16,6 +16,10 @@ Parameters:
         Description: Select the DNS zone to use for service discovery
         Type: String
 
+    ClusterArn:
+        Description: The ARN of the ECS cluster to monitor
+        Type: String
+
 Resources:
     CloudWatchEvents:
         Type: AWS::Events::Rule
@@ -46,7 +50,7 @@ Resources:
             Environment:
                 Variables:
                     DNS_ZONE: !Ref DNSZone
-                    CLUSTER_NAME: !Ref EnvironmentName
+                    CLUSTER_ARN: !Ref ClusterArn
             Code:
                 S3Bucket: !Ref S3BucketName
                 S3Key: !Ref S3Key

--- a/pkg/ecso/resources/environment/cloudformation/stack.yaml
+++ b/pkg/ecso/resources/environment/cloudformation/stack.yaml
@@ -137,6 +137,7 @@ Resources:
                 EnvironmentName: !Ref AWS::StackName
                 S3BucketName: !Ref S3BucketName
                 S3Key: !Sub ${S3KeyPrefix}/resources/lambda/service-discovery-{{.ServiceDiscoveryLambdaVersion}}.zip
+                ClusterArn: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${AWS::StackName}
 
     InstanceDrainerLambda:
         Type: AWS::CloudFormation::Stack

--- a/pkg/ecso/resources/environment/lambda/service-discovery/index.js
+++ b/pkg/ecso/resources/environment/lambda/service-discovery/index.js
@@ -8,28 +8,10 @@ const ecs = new AWS.ECS();
 const ec2 = new AWS.EC2();
 const r53 = new AWS.Route53();
 
-const processContainer = (zoneName, containerInstance, taskDefinition) => container => {
-    const createRecords = updateDnsForContainer("CREATE");
-    const deleteRecords = updateDnsForContainer("DELETE");
-
-    switch (container.lastStatus) {
-        case "RUNNING":
-            return createRecords(zoneName, containerInstance, taskDefinition, container);
-        case "STOPPED":
-            return deleteRecords(zoneName, containerInstance, taskDefinition, container);
-        default:
-            return Promise.resolve([]);
-    }
-}
-
-const updateDnsForContainer = action => (zoneName, containerInstance, taskDefinition, container) =>
-    getDnsZoneId(zoneName)
-    .then(zoneId => Promise.all(
-        containerResourceRecordSets(zoneName, containerInstance, taskDefinition, container)
-        .map(createChangeBatch(action, zoneId))
-        .map(changeResourceRecordSet)));
-
-const createChangeBatch = (action, zoneId) => resourceRecordSet => ({
+/*
+  Creates a route 53 change batch
+  */
+const changeBatch = (action, zoneId, resourceRecordSet) => ({
     ChangeBatch: {
         Changes: [{
             Action: action,
@@ -40,6 +22,9 @@ const createChangeBatch = (action, zoneId) => resourceRecordSet => ({
     HostedZoneId: zoneId
 });
 
+/*
+  Returns a promise for the DNS zone ID of the route 53 zone matching 'name'
+  */
 const getDnsZoneId = name => {
     var params = {
         DNSName: name
@@ -52,38 +37,49 @@ const getDnsZoneId = name => {
     });
 }
 
-const containerResourceRecordSets = (zoneName, containerInstance, taskDefinition, container) => {
-    const env = containerEnv(taskDefinition, container.name);
+/*
+  Creates an array of route 53 resource record sets for a given container. A record
+  set is created for each port and service name indicated by the presence of
+  SERVICE_<PORT>_NAME environment variables in the task definition
+  */
+const containerResourceRecordSets = (zoneName, containerInstance, taskDefinition, container) =>
+    serviceDiscoveryInfo(container, taskDefinition)
+    .map(info => containerResourceRecordSet(info.name, zoneName, findBinding(info.port, container.networkBindings), containerInstance, container.containerArn));
 
-    return env.reduce((records, envVar) => {
+/*
+  Returns an array of service discovery info object parsed from the env vars of
+  a container. Each info object has the form { name: string, port: number }
+  */
+const serviceDiscoveryInfo = (container, taskDefinition) =>
+    containerEnv(taskDefinition, container.name)
+    .map(envVarToServiceDiscoveryInfo)
+    .filter(info => info != null);
 
-        const info = envVarToServiceDiscoveryInfo(envVar);
-
-        if (info != null) {
-            records.push(
-                containerResourceRecordSet(
-                    info.name,
-                    zoneName,
-                    findBinding(info.port, container.networkBindings),
-                    containerInstance));
-        }
-
-        return records;
-    }, []);
-}
-
-const containerResourceRecordSet = (serviceName, dnsZone, networkBinding, containerInstance) => ({
+/*
+  Creates a resource record set for a container and network binding
+  */
+const containerResourceRecordSet = (serviceName, dnsZone, networkBinding, containerInstance, setIdentifier) => ({
     Name: serviceName + "." + dnsZone,
     Type: "SRV",
     TTL: 0,
+    SetIdentifier: setIdentifier,
+    Weight: 1,
     ResourceRecords: [{
         Value: srvRecord(1, 1, networkBinding.hostPort, containerInstance.PrivateDnsName)
     }]
 });
 
+/*
+  Creates an SRV DNS record
+  */
 const srvRecord = (priority, weight, port, hostname) =>
     priority + " " + weight + " " + port + " " + hostname;
 
+/*
+  Transforms an environment variable in the format SERVICE_<PORT>_NAME=<my.service>
+  into an object in the form { name: my.service, port: <PORT> }. If the environment
+  variable cannot be parsed, null is returned
+  */
 const envVarToServiceDiscoveryInfo = envVar => {
     const parts = envVar.name.split("_");
 
@@ -97,21 +93,44 @@ const envVarToServiceDiscoveryInfo = envVar => {
     return null;
 }
 
+/*
+  Returns an array of environment variables for a given container in a
+  task definition
+  */
 const containerEnv = (taskDefinition, name) =>
     taskDefinition.containerDefinitions.reduce((env, c) =>
         name == c.name ? c.environment : env, []);
 
+
+/*
+  Returns true if the the container has any service discovery env vars
+  */
+const hasServiceDiscoveryEnvVar = (container, taskDefinition) =>
+    serviceDiscoveryInfo(container, taskDefinition).length > 0;
+
+/*
+  Retrives a binding by container port from a list of bindings
+  */
 const findBinding = (containerPort, bindings) =>
     (bindings || []).reduce((binding, b) =>
         String(b.containerPort) == String(containerPort) ? b : binding, {});
 
-const changeResourceRecordSet = params =>
-    new Promise((resolve, reject) => {
+/*
+  Returns a promise for the result of calling the changeResourceRecordSets route 53
+  API method
+  */
+const executeChangeBatch = params => {
+    console.log("Executing change batch ", JSON.stringify(params));
+    return new Promise((resolve, reject) => {
         r53.changeResourceRecordSets(params, (err, data) => {
             err ? reject(err) : resolve(data);
         });
     });
+}
 
+/*
+  Returns a promise for the task definition indicated by arn
+  */
 const getTaskDefinition = arn =>
     new Promise((resolve, reject) => {
         ecs.describeTaskDefinition({
@@ -121,6 +140,9 @@ const getTaskDefinition = arn =>
         });
     });
 
+/*
+  Returns a promise for an ec2 instance matched by id
+  */
 const getEC2Instance = id =>
     new Promise((resolve, reject) => {
         ec2.describeInstances({
@@ -130,9 +152,16 @@ const getEC2Instance = id =>
         });
     });
 
+/*
+  Finds an ec2 instance by id from an array of ec2 instances
+  */
 const findInstanceById = (id, instances) =>
     instances.reduce((instance, i) => i.InstanceId === id ? i : instance, null);
 
+/*
+  Returns a promise for an ec2 container instance with the given arn, who is a
+  member of the given ecs cluster
+  */
 const getContainerInstance = (cluster, arn) => {
     const params = {
         cluster: cluster,
@@ -154,31 +183,123 @@ const getContainerInstance = (cluster, arn) => {
     });
 }
 
-const handleEvent = (zoneName, clusterName, event) => {
-    switch (event["detail-type"]) {
-        case "ECS Task State Change":
-            return handleTaskStateChangeEvent(zoneName, clusterName, event);
-        default:
-            return Promise.reject("Unknown event type " + event["detail-type"]);
-    }
+/*
+  Returns a promise for the result of handling a single ecs task change event
+  */
+const handleEvent = (zoneName, clusterArn, event) => {
+    const desiredState = isTaskStartedEvent(event) ? "RUNNING" : "STOPPED";
+
+    return Promise.all([
+        getContainerInstance(clusterArn, event.detail.containerInstanceArn),
+        getTaskDefinition(event.detail.taskDefinitionArn)
+    ]).then(([instance, taskDefinition]) =>
+        updateDnsForContainers(
+            desiredState,
+            filterDiscoverableContainers(event.detail.containers, taskDefinition),
+            zoneName,
+            instance,
+            taskDefinition));
 }
 
-const handleTaskStateChangeEvent = (zoneName, clusterName, event) => {
-    return getContainerInstance(clusterName, event.detail.containerInstanceArn)
-        .then(instance => {
-            return getTaskDefinition(event.detail.taskDefinitionArn)
-                .then(taskDefinition => {
-                    return Promise.all(event.detail.containers.map(processContainer(zoneName, instance, taskDefinition)));
-                });
-        });
-}
+/*
+  Returns a promise that will resolve after updating the DNS entries for a list
+  of containers in a single task definition
+  */
+const updateDnsForContainers = (desiredState, containers, zoneName, instance, taskDefinition) =>
+    Promise.all(containers.map(updateDnsForContainer(desiredState, zoneName, instance, taskDefinition)));
 
+/*
+  Returns a promise that will resolve after updating the DNS entries for a single
+  container in a task definition
+  */
+const updateDnsForContainer = (desiredState, zoneName, containerInstance, taskDefinition) => container =>
+    containerChangeBatches(desiredState, zoneName, containerInstance, taskDefinition, container)
+    .then(executeChangeBatches);
+
+/*
+  Filters non-discoverable containers from an array of containers
+  */
+const filterDiscoverableContainers = (containers, taskDefinition) =>
+    containers.filter(c => isDiscoverable(c, taskDefinition));
+
+/*
+  Returns true if a conainer is discoverable. A container must contain at least one network binding,
+  at least one service discovery env var and be in a terminal state in order to be considered
+  discoverable
+  */
+const isDiscoverable = (container, taskDefinition) =>
+    container.networkBindings != null &&
+    hasServiceDiscoveryEnvVar(container, taskDefinition) &&
+    (container.lastStatus === "RUNNING" || container.lastStatus === "STOPPED");
+
+/*
+  Returns true if an event is actionable. Curently only task started and task stopped events are
+  considered actionable
+  */
+const isActionableEvent = event =>
+    isTaskStartedEvent(event) || isTaskStoppedEvent(event);
+
+/*
+  Returns true if both the desiredStatus and lastStatus of the task are RUNNING
+  */
+const isTaskStartedEvent = event =>
+    isTaskStateChangedEvent(event) &&
+    (event.detail.desiredStatus === event.detail.lastStatus) &&
+    (event.detail.lastStatus === "RUNNING");
+
+/*
+  Returns true if the desiredStatus of the task is STOPPED
+  */
+const isTaskStoppedEvent = event =>
+    isTaskStateChangedEvent(event) && (event.detail.desiredStatus === "STOPPED");
+
+/*
+  Returns true if the event is a task changed event
+  */
+const isTaskStateChangedEvent = event =>
+    event["detail-type"] === "ECS Task State Change";
+
+/*
+  Returns a promise that wil resolve when all route 53 change batches have been
+  executed
+  */
+const executeChangeBatches = changeBatches =>
+    Promise.all(changeBatches.map(executeChangeBatch));
+
+/*
+  Returns a promise for an array of route 53 change batches for a container. The action for each
+  change set will be determined by the desiredState and the last known container state
+  */
+const containerChangeBatches = (desiredState, zoneName, containerInstance, taskDefinition, container) =>
+    getDnsZoneId(zoneName)
+    .then(zoneId =>
+        containerResourceRecordSets(zoneName, containerInstance, taskDefinition, container)
+        .map(rs => changeBatch(containerAction(desiredState, container), zoneId, rs)));
+
+/*
+  Converts a desiredState and last known container state into an appropriate route53 changeset
+  action. If either the desired or know state are STOPPED then return the delete action, otherwise
+  UPSERT
+  */
+const containerAction = (desiredState, container) =>
+    (container.lastStatus === "STOPPED" || desiredState === "STOPPED") ? "DELETE" : "UPSERT";
+
+/*
+  Lambda entry point
+  */
 exports.handler = function(event, context, cb) {
-    handleEvent(process.env.DNS_ZONE, process.env.CLUSTER_NAME, event)
-        .then(val => {
-            cb(null, val);
-        })
-        .catch(err => {
-            cb(err);
-        });
+    console.log(JSON.stringify(event));
+
+    if (isActionableEvent(event)) {
+        handleEvent(process.env.DNS_ZONE, process.env.CLUSTER_ARN, event)
+            .then(val => {
+                console.log(JSON.stringify(val));
+                cb(null, val);
+            })
+            .catch(err => {
+                cb(err);
+            });
+    } else {
+        cb(null, "Skipping unhandleable event");
+    }
 };


### PR DESCRIPTION
Replaces the ecssd agent running on each host in the cluster with an external lambda which will manage dns entries in response to ecs service events sent via cloudwatch events